### PR TITLE
feat: Add ByPart argument for splitting archives

### DIFF
--- a/Send-FileOverClipboard.ps1
+++ b/Send-FileOverClipboard.ps1
@@ -6,16 +6,53 @@
     7-Zip command-line tool (7z.exe) for compression. It will first look for 7z.exe
     in the system PATH, and if not found, will check the default install location.
 #>
+[CmdletBinding(DefaultParameterSetName='SingleFile')]
 param(
-    [Parameter(Mandatory=$true)]
+    [Parameter(Mandatory=$true, Position=0)]
     [string]$Path,
 
-    [int]$ChunkSize = 786432 # 768 KB
+    [Parameter(Mandatory=$false)]
+    [int]$ChunkSize = 786432, # 768 KB
+
+    [Parameter(Mandatory=$true, ParameterSetName='ByPart')]
+    [switch]$ByPart,
+
+    [Parameter(Mandatory=$true, ParameterSetName='ByPart')]
+    [string]$PartSize
 )
 
 function Write-Log {
     param([string]$Message, [string]$Color = "White")
     Write-Host "[$(Get-Date -Format 'HH:mm:ss')] $Message" -ForegroundColor $Color
+}
+
+function Parse-Size {
+    param([string]$SizeStr)
+    $SizeStr = $SizeStr.ToUpper().Trim()
+
+    # Correctly separate the numeric value from the unit string.
+    $valueStr = ($SizeStr -replace '[A-Z]').Trim()
+    $unit = ($SizeStr -replace '[0-9. ]').Trim()
+
+    if (-not $valueStr) {
+        Write-Log "Invalid size string: $SizeStr" -Color Red
+        return 0
+    }
+    $multiplier = 1
+    switch ($unit) {
+        "B"  { $multiplier = 1 }
+        "KB" { $multiplier = 1KB }
+        "MB" { $multiplier = 1MB }
+        "GB" { $multiplier = 1GB }
+        ""   { $multiplier = 1 } # Default to bytes if no unit
+    }
+    try {
+        # Use the correctly isolated numeric string for parsing.
+        return [int64]([double]::Parse($valueStr) * $multiplier)
+    } catch {
+        Write-Log "Failed to parse size string: '$SizeStr'. Could not parse value: '$valueStr'." -Color Red
+        return 0
+    }
 }
 
 # --- PRE-FLIGHT CHECK: Find 7z.exe ---
@@ -82,62 +119,119 @@ if ($needsArchiving) {
     }
 }
 
-# --- 2. HASH AND CHUNK THE FILE ---
-Write-Log "Computing SHA256 hash for '$archivePath'..." -Color Yellow
-$fileHash = (Get-FileHash -Path $archivePath -Algorithm SHA256).Hash
-Write-Log "SHA256 Hash: $fileHash" -Color Green
+function Send-File {
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]$FilePathToSend,
+        [Parameter(Mandatory=$true)]
+        [int]$TransferChunkSize
+    )
 
-$fileBytes = [System.IO.File]::ReadAllBytes($archivePath)
-$totalChunks = [System.Math]::Ceiling($fileBytes.Length / $ChunkSize)
-$archiveFileName = Split-Path $archivePath -Leaf
+    $fileToSendName = Split-Path $FilePathToSend -Leaf
+    Write-Log "Starting transfer process for '$fileToSendName'..." -Color Cyan
 
-Write-Log "File size: $($fileBytes.Length) bytes. Splitting into $totalChunks chunks." -Color Yellow
+    # --- HASH AND CHUNK THE FILE ---
+    Write-Log "Computing SHA256 hash for '$fileToSendName'..." -Color Yellow
+    $fileHash = (Get-FileHash -Path $FilePathToSend -Algorithm SHA256).Hash
+    Write-Log "SHA256 Hash: $fileHash" -Color Green
 
-# --- 3. SEND CHUNKS WITH ACKNOWLEDGEMENT ---
-for ($i = 0; $i -lt $totalChunks; $i++) {
-    $chunkNumber = $i + 1
-    $offset = $i * $ChunkSize
-    $remainingBytes = $fileBytes.Length - $offset
-    $currentChunkSize = [System.Math]::Min($ChunkSize, $remainingBytes)
+    $fileBytes = [System.IO.File]::ReadAllBytes($FilePathToSend)
+    $totalChunks = [System.Math]::Ceiling($fileBytes.Length / $TransferChunkSize)
 
-    $chunkBytes = $fileBytes[$offset..($offset + $currentChunkSize - 1)]
-    $chunkBase64 = [System.Convert]::ToBase64String($chunkBytes)
+    Write-Log "File size: $($fileBytes.Length) bytes. Splitting into $totalChunks chunks of max $TransferChunkSize bytes." -Color Yellow
 
-    $payload = @{
-        filename     = $archiveFileName
-        hash         = $fileHash
-        chunk_number = $chunkNumber
-        total_chunks = $totalChunks
-        data         = $chunkBase64
-    } | ConvertTo-Json -Compress
+    # --- SEND CHUNKS WITH ACKNOWLEDGEMENT ---
+    for ($i = 0; $i -lt $totalChunks; $i++) {
+        $chunkNumber = $i + 1
+        $offset = $i * $TransferChunkSize
+        $remainingBytes = $fileBytes.Length - $offset
+        $currentChunkSize = [System.Math]::Min($TransferChunkSize, $remainingBytes)
 
-    $ackReceived = $false
-    while (-not $ackReceived) {
-        Write-Log "Sending chunk $chunkNumber/$totalChunks..." -Color Cyan
-        Set-Clipboard -Value $payload
-        
-        $expectedAck = "ACK $chunkNumber"
-        Write-Log "Waiting for acknowledgement: '$expectedAck'" -Color Yellow
-        
-        $timeout = 0
-        while ($timeout -lt 300) {
-            $clipboardContent = Get-Clipboard
-            if ($clipboardContent -eq $expectedAck) {
-                Write-Log "ACK received for chunk $chunkNumber!" -Color Green
-                $ackReceived = $true
-                break
+        $chunkBytes = $fileBytes[$offset..($offset + $currentChunkSize - 1)]
+        $chunkBase64 = [System.Convert]::ToBase64String($chunkBytes)
+
+        $payload = @{
+            filename     = $fileToSendName
+            hash         = $fileHash
+            chunk_number = $chunkNumber
+            total_chunks = $totalChunks
+            data         = $chunkBase64
+        } | ConvertTo-Json -Compress
+
+        $ackReceived = $false
+        while (-not $ackReceived) {
+            Write-Log "Sending chunk $chunkNumber/$totalChunks for '$fileToSendName'..." -Color Cyan
+            Set-Clipboard -Value $payload
+
+            $expectedAck = "ACK $chunkNumber"
+            Write-Log "Waiting for acknowledgement: '$expectedAck'" -Color Yellow
+
+            $timeout = 0
+            while ($timeout -lt 300) { # 60 seconds timeout
+                $clipboardContent = Get-Clipboard
+                if ($clipboardContent -eq $expectedAck) {
+                    Write-Log "ACK received for chunk $chunkNumber!" -Color Green
+                    $ackReceived = $true
+                    break
+                }
+                Start-Sleep -Milliseconds 200
+                $timeout++
             }
-            Start-Sleep -Milliseconds 200
-            $timeout++
-        }
 
-        if (-not $ackReceived) {
-             Write-Log "Timeout waiting for ACK for chunk $chunkNumber. Retrying..." -Color Red
+            if (-not $ackReceived) {
+                 Write-Log "Timeout waiting for ACK for chunk $chunkNumber. Retrying..." -Color Red
+            }
         }
     }
+
+    Write-Log "File transfer complete for '$fileToSendName'." -Color Green
 }
 
-Write-Log "File transfer complete for '$archiveFileName'." -Color Green
+# --- 2. TRANSFER LOGIC ---
+if ($ByPart.IsPresent) {
+    $partSizeBytes = Parse-Size $PartSize
+    if ($partSizeBytes -eq 0) {
+        # Error message was already printed by Parse-Size. Exit gracefully.
+        return
+    }
+
+    Write-Log "Splitting '$archivePath' into parts of up to $PartSize..." -Color Yellow
+
+    $fullFileBytes = [System.IO.File]::ReadAllBytes($archivePath)
+    $fullFileSize = $fullFileBytes.Length
+    $archiveFileLeafName = Split-Path $archivePath -Leaf
+    $partNumber = 1
+    $offset = 0
+
+    while ($offset -lt $fullFileSize) {
+        $bytesRemaining = $fullFileSize - $offset
+        $currentPartSize = [System.Math]::Min($partSizeBytes, $bytesRemaining)
+
+        $partBytes = $fullFileBytes[$offset..($offset + $currentPartSize - 1)]
+
+        $tempPartFileName = "$($archiveFileLeafName).part$($partNumber.ToString('000'))"
+        $tempPartPath = Join-Path $env:TEMP $tempPartFileName
+
+        Write-Log "Preparing part #$partNumber: '$tempPartFileName' ($currentPartSize bytes)" -Color Cyan
+        [System.IO.File]::WriteAllBytes($tempPartPath, $partBytes)
+
+        # Send this part using the refactored function
+        Send-File -FilePathToSend $tempPartPath -TransferChunkSize $ChunkSize
+
+        # Clean up the temporary part file
+        Remove-Item $tempPartPath -Force
+        Write-Log "Cleaned up temporary part file '$tempPartFileName'." -Color Yellow
+
+        $offset += $currentPartSize
+        $partNumber++
+    }
+
+    Write-Log "All parts have been transferred." -Color Green
+
+} else {
+    Send-File -FilePathToSend $archivePath -TransferChunkSize $ChunkSize
+}
+
 
 if ($needsArchiving) {
     Remove-Item $archivePath -Force


### PR DESCRIPTION
This commit introduces a new feature to the `Send-FileOverClipboard.ps1` script that allows splitting the source archive into smaller parts for transfer.

A new parameter set has been added:
- `-ByPart`: A switch to enable the new functionality.
- `-PartSize`: A mandatory string argument (e.g., "10MB", "512KB") to specify the maximum size of each part.

When `-ByPart` is used, the script performs the following steps:
1. Creates the `.7z` archive as usual.
2. Splits the archive into multiple part files based on the specified `-PartSize`.
3. Transfers each part file individually using the existing chunking and acknowledgement protocol. Each part is treated as a self-contained file with its own hash for verification.

The core transfer logic has been refactored into a reusable `Send-File` function to support both single-file and multi-part transfers without code duplication. A `Parse-Size` helper function was also added to handle human-readable size inputs.

This approach requires no changes to the `Receive-FileFromClipboard.ps1` script, as it will simply receive a sequence of part files (e.g., `archive.7z.part001`, `archive.7z.part002`), which it already supports.